### PR TITLE
Added initial data structures.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(field_init_shorthand)]
 mod sg;
 
-pub use sg::App;
+pub use sg::{App, InputSource, ReturnType};

--- a/src/sg/app.rs
+++ b/src/sg/app.rs
@@ -20,12 +20,29 @@ pub struct App {
 impl App {
 
     pub fn new(headless: bool, filter: String, input: InputSource, return_type: ReturnType) -> Self {
-        App { headless, unfiltered_results: vec![], filtered_results: vec![], filter, input, return_type }
+        App { headless, filter, input, return_type, unfiltered_results: vec![], filtered_results: vec![] }
     }
 
     pub fn start(&self) -> i32 {
-        if self.headless { println!("Running in headless mode!") }
+        self.create_ui();
+        self.start_filtering();
+        self.update_ui();
         0
+    }
+
+
+    //-------- private ---------//
+
+    fn create_ui(&self) {
+        if self.headless { println!("Running in headless mode!") }
+    }
+
+    fn start_filtering(&self) {
+        // TODO
+    }
+
+    fn update_ui(&self) {
+        // TODO
     }
 
 }

--- a/src/sg/app.rs
+++ b/src/sg/app.rs
@@ -1,18 +1,17 @@
 pub struct App {
     headless: bool,
+    unfiltered_results: Vec<String>,
+    filtered_results: Vec<String>,
 }
 
 impl App {
 
     pub fn new(headless: bool) -> Self {
-        App { headless: headless }
+        App { headless: headless, unfiltered_results: vec![], filtered_results: vec![] }
     }
 
     pub fn start(&self) -> i32 {
-        match self.headless {
-            true => { println!("Running in headless mode!") }
-            false => { println!("Running in UI mode!") }
-        }
+        if self.headless { println!("Running in headless mode!") }
         0
     }
 

--- a/src/sg/app.rs
+++ b/src/sg/app.rs
@@ -1,13 +1,26 @@
+pub enum InputSource {
+    Fixed(Vec<String>),
+    Stdin,
+}
+
+pub enum ReturnType {
+    All,
+    Selected,
+}
+
 pub struct App {
     headless: bool,
     unfiltered_results: Vec<String>,
     filtered_results: Vec<String>,
+    filter: String,
+    input: InputSource,
+    return_type: ReturnType,
 }
 
 impl App {
 
-    pub fn new(headless: bool) -> Self {
-        App { headless: headless, unfiltered_results: vec![], filtered_results: vec![] }
+    pub fn new(headless: bool, filter: String, input: InputSource, return_type: ReturnType) -> Self {
+        App { headless, unfiltered_results: vec![], filtered_results: vec![], filter, input, return_type }
     }
 
     pub fn start(&self) -> i32 {

--- a/src/sg/mod.rs
+++ b/src/sg/mod.rs
@@ -1,3 +1,3 @@
 mod app;
 
-pub use self::app::App;
+pub use self::app::{App, InputSource, ReturnType};


### PR DESCRIPTION
This are my initial thoughts about the start of the app.

I've added a `--headless` flag that I think will be helpful with end to end tests.

From our last discussions we talked about keeping it simple in the beginning.

Why don't we keep it super simple and support headless first, and only 1 thread.

So all interaction is via the cli, for example:

```
sg --headless --input "superman\njoker\nbatman" --filter man --return all-rows
```

This would return:

```
superman
batman
```

and we can then run tests on this. 

So we would be able to test basic filtering, different filtering algorithms, benchmark the speed of finding results and stuff like that.

What do you think?

I've had trouble previously when the only way to test the app end to end was via curses.